### PR TITLE
Add support to ESP32 platform

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -67,6 +67,12 @@ framework = arduino
 board_build.core = earlephilhower
 upload_protocol = picotool
 
+[env:esp32]
+platform = espressif32
+board = esp32dev
+framework = arduino
+upload_protocol = esptool
+
 ; pio run -e teensy40 --target upload --upload-port /dev/ttyACM0
 ; pio run -e teensy40 -t envdump
 ; pio device monitor

--- a/src/Converter.hpp
+++ b/src/Converter.hpp
@@ -22,6 +22,15 @@ public:
     uint8_t clock_frequency_mhz = CLOCK_FREQUENCY_MHZ_DEFAULT;
     int32_t microsteps_per_real_position_unit = MICROSTEPS_PER_REAL_POSITION_UNIT_DEFAULT;
     int32_t seconds_per_real_velocity_unit = SECONDS_PER_REAL_VELOCITY_UNIT_DEFAULT;
+
+    Settings(uint8_t clock_frequency_mhz_ = CLOCK_FREQUENCY_MHZ_DEFAULT,
+      int32_t microsteps_per_real_position_unit_ = MICROSTEPS_PER_REAL_POSITION_UNIT_DEFAULT,
+      int32_t seconds_per_real_velocity_unit_ = SECONDS_PER_REAL_VELOCITY_UNIT_DEFAULT)
+    {
+      clock_frequency_mhz = clock_frequency_mhz_;
+      microsteps_per_real_position_unit = microsteps_per_real_position_unit_;
+      seconds_per_real_velocity_unit = seconds_per_real_velocity_unit_;
+    };
   };
   void setup(Settings settings);
 

--- a/src/TMC51X0/UartInterface.cpp
+++ b/src/TMC51X0/UartInterface.cpp
@@ -187,6 +187,13 @@ uint8_t UartInterface::calculateCrc(Datagram & datagram,
   return crc;
 }
 
+#if defined(ARDUINO_ARCH_ESP32)
+void digitalWriteFast(uint8_t pin, uint8_t val)
+{
+  val ? GPIO.out_w1ts = (1 << pin) : GPIO.out_w1tc = (1 << pin);
+}
+#endif
+
 void UartInterface::enableTx()
 {
   digitalWriteFast(uart_parameters_.enable_tx_pin, uart_parameters_.enable_tx_polarity);


### PR DESCRIPTION
First of all, congratulations on the library! I think it's fantastic compared to other alternatives. Extending support to the ESP32 is a great idea, and only a few changes are needed to ensure the library builds smoothly on the ESP32 platform.